### PR TITLE
Don't try to render source if vacuum doesn't support it

### DIFF
--- a/src/vacuum-card.js
+++ b/src/vacuum-card.js
@@ -159,6 +159,10 @@ class VacuumCard extends LitElement {
       this.entity
     );
 
+    if (!sources) {
+      return html``;
+    }
+
     const selected = sources.indexOf(source);
 
     return html` <paper-menu-button


### PR DESCRIPTION
For the Roomba 980, fan speed isn't supported so the card crashes and doesn't display. 
This fixes that by doing a simple check and won't try to query the fan speed list if it doesn't exist.

This would have fixed #7 and (I think) fixes #14 .