### PR TITLE
Change style to blend with other cards and themes

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -17,7 +17,7 @@ export default css`
   }
 
   .preview {
-    background: var(--primary-color);
+    background: var(--paper-card-background-color);
     cursor: pointer;
     overflow: hidden;
     position: relative;
@@ -128,7 +128,6 @@ export default css`
 
   .battery {
     text-align: right;
-    font-weight: bold;
     padding: 9px 20px;
   }
 
@@ -140,7 +139,6 @@ export default css`
     height: 40px;
     display: flex;
     align-items: center;
-    font-weight: bold;
     padding: 9px 20px;
     text-align: left;
   }
@@ -162,7 +160,7 @@ export default css`
     text-align: center;
     font-weight: bold;
     margin: 10px auto 20px;
-    color: var(--text-primary-color);
+    color: var(--text-color);
     font-size: 16px;
   }
 
@@ -171,7 +169,7 @@ export default css`
     display: flex;
     flex-direction: row;
     justify-content: space-evenly;
-    color: var(--text-primary-color);
+    color: var(--text-color);
   }
 
   .stats-block {
@@ -187,15 +185,14 @@ export default css`
 
   .stats-hours {
     font-size: 20px;
-    font-weight: bold;
   }
 
   ha-icon {
-    color: #fff;
+    color: var(--paper-dialog-button-color);
   }
 
   .toolbar {
-    background: var(--lovelace-background, var(--primary-background-color));
+    background: var(--primary-background-color);
     min-height: 30px;
     display: flex;
     flex-direction: row;
@@ -203,7 +200,7 @@ export default css`
   }
 
   .toolbar ha-icon-button {
-    color: var(--primary-color);
+    color: var(--paper-dialog-button-color);
     flex-direction: column;
     width: 44px;
     height: 44px;
@@ -220,7 +217,7 @@ export default css`
   }
 
   .toolbar paper-button {
-    color: var(--primary-color);
+    color: var(--paper-dialog-button-color);
     flex-direction: column;
     margin-right: 10px;
     padding: 15px 10px;
@@ -234,12 +231,12 @@ export default css`
   }
 
   .toolbar paper-button {
-    color: var(--primary-color);
+    color: var(--paper-dialog-button-color);
     flex-direction: row;
   }
 
   .toolbar ha-icon {
-    color: var(--primary-color);
+    color: var(--paper-dialog-button-color);
     padding-right: 15px;
   }
 
@@ -249,7 +246,7 @@ export default css`
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    color: var(--text-primary-color);
+    color: var(--text-color);
   }
 
   .header div {


### PR DESCRIPTION
See discussion in denysdovhan/vacuum-card#5.

---

In the [commit](https://github.com/alexander-bauer/vacuum-card/commit/4c5d1d833e9d1b7d555922ec61baaa00296ab1c4) I just made on my fork, I changed all variables in the style to match the theme variables, to my best estimation. These are the results on the default, [clear](https://github.com/naofireblade/clear-theme), and [clear-dark](https://github.com/naofireblade/clear-theme-dark). There might be some tweaks left to make, but I think it's undeniable that it blends better with the rest of the interface.

![Screenshot 2020-05-25 at 3 41 49 PM](https://user-images.githubusercontent.com/1558334/82839989-1e167b80-9e9f-11ea-8992-d410c1d5c196.png)
![Screenshot 2020-05-25 at 3 42 03 PM](https://user-images.githubusercontent.com/1558334/82839988-1e167b80-9e9f-11ea-97f8-e6213da2529f.png)
![Screenshot 2020-05-25 at 3 42 20 PM](https://user-images.githubusercontent.com/1558334/82839986-1d7de500-9e9f-11ea-96cf-7f210648001e.png)

That said, there remains the issue of giving the option to change the palette back to using the primary and background colors in the way @denysdovhan does. To that end, I think @firstof9's approach might be easiest to stomach: where I have changed the styles, we change them again to use `--vacuum-card-*` style variables which fall back to the new values given in my fork. Then themes can be made to set these explicitly, to achieve the original styling or new custom stylings, and when unset the defaults will match other cards in the theme.