### PR TITLE
Simplify valetudo state retrieval

### DIFF
--- a/src/vacuum-card.js
+++ b/src/vacuum-card.js
@@ -158,18 +158,16 @@ class VacuumCard extends LitElement {
   getAttributes(entity) {
     const {
       status,
+      state,
       fan_speed,
       fan_speed_list,
       battery_level,
       battery_icon,
       friendly_name,
-      valetudo_state,
     } = entity.attributes;
 
-    const valetudoStatus = valetudo_state ? valetudo_state.name : '';
-
     return {
-      status: status || valetudoStatus,
+      status: status || state,
       fan_speed,
       fan_speed_list,
       battery_level,


### PR DESCRIPTION
I noticed that state status wasn't displaying for my valetudo-powered vacuum. Turns out `valetudo_state` is not an object anymore. However, I noticed that `state` attribute is unused and I thought it would be even better to rely on that instead, so it would be consistent with other cards.

<img width="750" alt="Developer Tools - Home Assistant 2020-06-06 19-26-40" src="https://user-images.githubusercontent.com/944286/83949332-d0e5c280-a82b-11ea-8d97-15511cd2eb52.png">
