### PR TITLE
Add iRobot Roomba i7+ to supported vacuums

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ If this card works with your vacuum cleaner, please open a PR and your model to 
 - Xiaomi Mi Robot 1S
 - Roomba 675
 - Roomba 960
+- Roomba i7+
 - Dyson 360 Eye
 - Neato D7
 - Neato D6


### PR DESCRIPTION
Working on iRobot Roomba i7+ (7550)

Thank you for this great card!