### PR TITLE
Address crash in `map` when using compact view

### DIFF
--- a/src/vacuum-card.js
+++ b/src/vacuum-card.js
@@ -129,7 +129,7 @@ class VacuumCard extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    if (this.map) {
+    if (!this.compactView && this.map) {
       this.updateCameraImage();
       this.thumbUpdater = setInterval(
         () => this.updateCameraImage(),


### PR DESCRIPTION
I'm using `compact_view: true` option and getting this crash when card is first rendered:

<img width="450" alt="Overview - Home Assistant 2020-10-17 15-58-02" src="https://user-images.githubusercontent.com/944286/96337698-8e61ab80-1091-11eb-8998-4dd14bec5657.png">

Maybe it's related to the fact that I'm using [browser_mod](https://github.com/thomasloven/hass-browser_mod#replacing-more-info-dialogs) feature to render this card in place of more-info...

But I thought that not running the code related to `updateCameraImage` when in `compactView` would be reasonable anyway, since it's not going to be used.