### PR TITLE
Support for nested attributes in stats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2144,6 +2144,11 @@
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "log-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "license": "MIT",
   "dependencies": {
     "custom-card-helpers": "^1.6.4",
-    "lit-element": "^2.3.1"
+    "lit-element": "^2.3.1",
+    "lodash.get": "^4.4.2"
   },
   "devDependencies": {
     "@babel/core": "^7.9.6",

--- a/src/vacuum-card.js
+++ b/src/vacuum-card.js
@@ -1,5 +1,6 @@
 import { LitElement, html } from 'lit-element';
 import { hasConfigOrEntityChanged, fireEvent } from 'custom-card-helpers';
+import get from 'lodash.get';
 import './vacuum-card-editor';
 import localize from './localize';
 import styles from './styles';
@@ -266,14 +267,9 @@ class VacuumCard extends LitElement {
         return html``;
       }
 
-      const [attributePrefix, attributeSuffix] = attribute.split('.');
-      let value = entity_id
+      const value = entity_id
         ? this.hass.states[entity_id].state
-        : this.entity.attributes[attributePrefix];
-
-      if (attributeSuffix) {
-        value = value[attributeSuffix];
-      }
+        : get(this.entity.attributes, attribute);
 
       return html`
         <div class="stats-block">

--- a/src/vacuum-card.js
+++ b/src/vacuum-card.js
@@ -266,9 +266,14 @@ class VacuumCard extends LitElement {
         return html``;
       }
 
-      const value = entity_id
+      const [attributePrefix, attributeSuffix] = attribute.split('.');
+      let value = entity_id
         ? this.hass.states[entity_id].state
-        : this.entity.attributes[attribute];
+        : this.entity.attributes[attributePrefix];
+
+      if (attributeSuffix) {
+        value = value[attributeSuffix];
+      }
 
       return html`
         <div class="stats-block">


### PR DESCRIPTION
I'm using [valetudo](https://valetudo.cloud/) firmware for my vacuum, and for most part this card works beautifully. But for some weird reason those valetudo folks decided it's a good idea to expose some of the vacuum data nested inside `last_run_stats` MQTT attribute. So with this patch I can do something like this:

```yml
stats:
  default:
    - attribute: filter
      unit: hours
      subtitle: Filter
    - attribute: last_run_stats.area
      unit: m2
      subtitle: Cleaning area
```