### PR TITLE
Fallback to entity.state for status and lowercase all translation keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ This card supports translations. Please, help to add more translations and impro
 
 - English
 - Українська (Ukrainian)
-- Deutsche (German)
+- Deutsch (German)
 - Français (French)
 - Italiano (Italian)
 - Nederlands (Dutch)
@@ -191,6 +191,7 @@ If this card works with your vacuum cleaner, please open a PR and your model to 
 - Neato D7
 - Neato D6
 - Shark IQ
+- Ecovacs Deebot 950
 - [_Your vacuum?_][edit-readme]
 
 ## Development

--- a/src/localize.js
+++ b/src/localize.js
@@ -34,22 +34,22 @@ var languages = {
   sv,
   nb,
   da,
-  ko
+  ko,
 };
 
 const DEFAULT_LANG = 'en';
 
 export default function localize(string, search, replace) {
-  const [section, key] = string.split('.');
+  const [section, key] = string.toLowerCase().split('.');
 
   let langStored;
-  
+
   try {
     langStored = JSON.parse(localStorage.getItem('selectedLanguage'));
   } catch (e) {
     langStored = localStorage.getItem('selectedLanguage');
-  };
-  
+  }
+
   const lang = (langStored || navigator.language.split('-')[0] || DEFAULT_LANG)
     .replace(/['"]+/g, '')
     .replace('-', '_');

--- a/src/translations/cs.json
+++ b/src/translations/cs.json
@@ -1,17 +1,17 @@
 {
   "status": {
-    "Cleaning": "Vysává se",
-    "Paused": "Pozastaveno",
-    "Idle": "Nečinný",
-    "Charging": "Nabíjí se",
-    "Returning home": "Vrací se domů"
+    "cleaning": "Vysává se",
+    "paused": "Pozastaveno",
+    "idle": "Nečinný",
+    "charging": "Nabíjí se",
+    "returning home": "Vrací se domů"
   },
   "source": {
-    "Gentle": "Mírný",
-    "Silent": "Tichý",
-    "Standard": "Standardní",
-    "Medium": "Střední",
-    "Turbo": "Turbo"
+    "gentle": "Mírný",
+    "silent": "Tichý",
+    "standard": "Standardní",
+    "medium": "Střední",
+    "turbo": "Turbo"
   },
   "common": {
     "name": "Karta vysavače",

--- a/src/translations/da.json
+++ b/src/translations/da.json
@@ -1,17 +1,17 @@
 {
   "status": {
-    "Cleaning": "Støvsuger",
-    "Paused": "Pauset",
-    "Idle": "Inaktiv",
-    "Charging": "Lader",
-    "Returning home": "Returnerer til dock"
+    "cleaning": "Støvsuger",
+    "paused": "Pauset",
+    "idle": "Inaktiv",
+    "charging": "Lader",
+    "returning home": "Returnerer til dock"
   },
   "source": {
-    "Gentle": "Mild",
-    "Silent": "Stille",
-    "Standard": "Standard",
-    "Medium": "Medium",
-    "Turbo": "Turbo"
+    "gentle": "Mild",
+    "silent": "Stille",
+    "standard": "Standard",
+    "medium": "Medium",
+    "turbo": "Turbo"
   },
   "common": {
     "name": "Vacuum Card",

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -1,38 +1,39 @@
 {
-    "status": {
-      "Cleaning": "Reinigen",
-      "Paused": "Pausiert",
-      "Idle": "Untätig",
-      "Charging": "Aufladen",
-      "Returning home": "Rückkehr zu Dockingstation",
-      "Segment cleaning": "Zimmerreinigung"
-    },
-    "common": {
-      "name": "Vacuum Card",
-      "description": "Vacuum card ermöglicht es Ihnen, Ihr Staubsaugerroboter zu steuern.",
-      "start": "Reinigen",
-      "continue": "Weiter",
-      "pause": "Pause",
-      "stop": "Stop",
-      "return_to_base": "Dock",
-      "locate": "Staubsauger lokalisieren"
-    },
-    "error": {
-      "missing_entity": "Angabe der Entität ist erforderlich!"
-    },
-    "editor": {
-      "entity": "Entität (Erforderlich)",
-      "map": "Map Camera (Optional)",
-      "image": "Bild (Optional)",
-      "compact_view": "kompakte Ansicht",
-      "compact_view_aria_label_on": "Schalte kompakte Ansicht ein",
-      "compact_view_aria_label_off": "Schalte kompakte Ansicht aus",
-      "show_name": "Zeige Namen",
-      "show_name_aria_label_on": "Schalte 'Zeige Namen' ein",
-      "show_name_aria_label_off": "Schalte 'Zeige Namen' aus",
-      "show_toolbar": "Zeige Toolbar",
-      "show_toolbar_aria_label_on": "Schalte 'Zeige Toolbar' ein",
-      "show_toolbar_aria_label_off": "Schalte 'Zeige Toolbar' aus",
-      "code_only_note": "Hinweis: Das Festlegen von Aktionen und Statistikoptionen ist ausschließlich mit dem Code-Editor möglich."
-    }
+  "status": {
+    "cleaning": "Reinigen",
+    "paused": "Pausiert",
+    "idle": "Untätig",
+    "charging": "Aufladen",
+    "returning home": "Rückkehr zu Dockingstation",
+    "segment cleaning": "Zimmerreinigung",
+    "docked": "Angedockt"
+  },
+  "common": {
+    "name": "Vacuum Card",
+    "description": "Vacuum card ermöglicht es Ihnen, Ihr Staubsaugerroboter zu steuern.",
+    "start": "Reinigen",
+    "continue": "Weiter",
+    "pause": "Pause",
+    "stop": "Stop",
+    "return_to_base": "Dock",
+    "locate": "Staubsauger lokalisieren"
+  },
+  "error": {
+    "missing_entity": "Angabe der Entität ist erforderlich!"
+  },
+  "editor": {
+    "entity": "Entität (Erforderlich)",
+    "map": "Map Camera (Optional)",
+    "image": "Bild (Optional)",
+    "compact_view": "kompakte Ansicht",
+    "compact_view_aria_label_on": "Schalte kompakte Ansicht ein",
+    "compact_view_aria_label_off": "Schalte kompakte Ansicht aus",
+    "show_name": "Zeige Namen",
+    "show_name_aria_label_on": "Schalte 'Zeige Namen' ein",
+    "show_name_aria_label_off": "Schalte 'Zeige Namen' aus",
+    "show_toolbar": "Zeige Toolbar",
+    "show_toolbar_aria_label_on": "Schalte 'Zeige Toolbar' ein",
+    "show_toolbar_aria_label_off": "Schalte 'Zeige Toolbar' aus",
+    "code_only_note": "Hinweis: Das Festlegen von Aktionen und Statistikoptionen ist ausschließlich mit dem Code-Editor möglich."
   }
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,17 +1,18 @@
 {
   "status": {
-    "Cleaning": "Cleaning",
-    "Paused": "Paused",
-    "Idle": "Idle",
-    "Charging": "Charging",
-    "Returning home": "Returning home"
+    "cleaning": "Cleaning",
+    "paused": "Paused",
+    "idle": "Idle",
+    "charging": "Charging",
+    "returning home": "Returning home",
+    "docked": "Docked"
   },
   "source": {
-    "Gentle": "Gentle",
-    "Silent": "Silent",
-    "Standard": "Standard",
-    "Medium": "Medium",
-    "Turbo": "Turbo"
+    "gentle": "Gentle",
+    "silent": "Silent",
+    "standard": "Standard",
+    "medium": "Medium",
+    "turbo": "Turbo"
   },
   "common": {
     "name": "Vacuum Card",

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -1,18 +1,18 @@
 {
   "status": {
-    "Cleaning": "Limpiando",
-    "Paused": "En pausa",
-    "Idle": "Inactivo",
-    "Charging": "Cargando",
-    "Returning home": "Volviendo a la base",
-    "Segment cleaning": "Limpiando zona"
+    "cleaning": "Limpiando",
+    "caused": "En pausa",
+    "idle": "Inactivo",
+    "charging": "Cargando",
+    "returning home": "Volviendo a la base",
+    "segment cleaning": "Limpiando zona"
   },
   "source": {
-    "Gentle": "Delicado",
-    "Silent": "Silencioso",
-    "Standard": "Standard",
-    "Medium": "Medio",
-    "Turbo": "Turbo"
+    "gentle": "Delicado",
+    "silent": "Silencioso",
+    "standard": "Standard",
+    "medium": "Medio",
+    "turbo": "Turbo"
   },
   "common": {
     "name": "Vacuum Card",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -1,17 +1,17 @@
 {
   "status": {
-    "Cleaning": "Nettoyage",
-    "Paused": "En pause",
-    "Idle": "Inactif",
-    "Charging": "En charge",
-    "Returning home": "Retour à la base"
+    "cleaning": "Nettoyage",
+    "paused": "En pause",
+    "idle": "Inactif",
+    "charging": "En charge",
+    "returning home": "Retour à la base"
   },
   "source": {
-    "Gentle": "Doux",
-    "Silent": "Silencieux",
-    "Standard": "Standard",
-    "Medium": "Moyen",
-    "Turbo": "Turbo"
+    "gentle": "Doux",
+    "silent": "Silencieux",
+    "standard": "Standard",
+    "medium": "Moyen",
+    "turbo": "Turbo"
   },
   "common": {
     "name": "Vacuum Carte",

--- a/src/translations/he.json
+++ b/src/translations/he.json
@@ -1,48 +1,48 @@
 {
-	"status": {
-		"Cleaning": "מנקה",
-		"Paused": "מושהה",
-		"Idle": "סרק",
-		"Charging": "בטעינה",
-		"Returning home": "בחזרה הביתה"
-	},
-	"source": {
-		"Gentle": "עדין",
-		"Silent": "שקט",
-		"Standard": "רגיל",
-		"Medium": "בינוני",
-		"Turbo": "טורבו"
-	},
-	"common": {
-		"name": "כרטיס שואב",
-		"description": "כרטיס שואב מאפשר לך שליטה על שואב האבק שלך.",
-		"start": "נקה",
-		"continue": "המשך",
-		"pause": "השהה",
-		"stop": "עצור",
-		"return_to_base": "הגינה",
-		"locate": "אתר שואב",
-		"not_available": "השואב אינו זמין"
-	},
-	"error": {
-		"missing_entity": "יש צורך לציין ישות!"
-	},
-	"editor": {
-		"entity": "ישות (נדרש)",
-		"map": "מצלמת מפה (אפשרי)",
-		"image": "תמונה (אפשרי)",
-		"compact_view": "תצוגה קומפקטית",
-		"compact_view_aria_label_on": "החלף תצוגה קומפקטית",
-		"compact_view_aria_label_off": "כבה את התצוגה הקומפקטית",
-		"show_name": "שם תצוגה",
-		"show_name_aria_label_on": "הפעל את שם התצוגה למצב מופעל",
-		"show_name_aria_label_off": "כבה את שם התצוגה",
-		"show_status": "הצג סטטוס",
-		"show_status_aria_label_on": "הפעל את מצב התצוגה למצב פעיל",
-		"show_status_aria_label_off": "כבה את מצב התצוגה",
-		"show_toolbar": "הצג סרגל כלים",
-		"show_toolbar_aria_label_on": "הפעל את סרגל הכלים לתצוגה",
-		"show_toolbar_aria_label_off": "כבה את סרגל הכלים לתצוגה",
-		"code_only_note": "הערה: הגדרת פעולות ואפשרויות סטטיסטיקה זמינות אך ורק באמצעות עורך הקוד."
-	}
+  "status": {
+    "cleaning": "מנקה",
+    "paused": "מושהה",
+    "idle": "סרק",
+    "charging": "בטעינה",
+    "returning home": "בחזרה הביתה"
+  },
+  "source": {
+    "gentle": "עדין",
+    "silent": "שקט",
+    "standard": "רגיל",
+    "medium": "בינוני",
+    "turbo": "טורבו"
+  },
+  "common": {
+    "name": "כרטיס שואב",
+    "description": "כרטיס שואב מאפשר לך שליטה על שואב האבק שלך.",
+    "start": "נקה",
+    "continue": "המשך",
+    "pause": "השהה",
+    "stop": "עצור",
+    "return_to_base": "הגינה",
+    "locate": "אתר שואב",
+    "not_available": "השואב אינו זמין"
+  },
+  "error": {
+    "missing_entity": "יש צורך לציין ישות!"
+  },
+  "editor": {
+    "entity": "ישות (נדרש)",
+    "map": "מצלמת מפה (אפשרי)",
+    "image": "תמונה (אפשרי)",
+    "compact_view": "תצוגה קומפקטית",
+    "compact_view_aria_label_on": "החלף תצוגה קומפקטית",
+    "compact_view_aria_label_off": "כבה את התצוגה הקומפקטית",
+    "show_name": "שם תצוגה",
+    "show_name_aria_label_on": "הפעל את שם התצוגה למצב מופעל",
+    "show_name_aria_label_off": "כבה את שם התצוגה",
+    "show_status": "הצג סטטוס",
+    "show_status_aria_label_on": "הפעל את מצב התצוגה למצב פעיל",
+    "show_status_aria_label_off": "כבה את מצב התצוגה",
+    "show_toolbar": "הצג סרגל כלים",
+    "show_toolbar_aria_label_on": "הפעל את סרגל הכלים לתצוגה",
+    "show_toolbar_aria_label_off": "כבה את סרגל הכלים לתצוגה",
+    "code_only_note": "הערה: הגדרת פעולות ואפשרויות סטטיסטיקה זמינות אך ורק באמצעות עורך הקוד."
+  }
 }

--- a/src/translations/hu.json
+++ b/src/translations/hu.json
@@ -1,17 +1,17 @@
 {
   "status": {
-    "Cleaning": "Tisztítás",
-    "Paused": "Szünet",
-    "Idle": "Tétlen",
-    "Charging": "Töltés",
-    "Returning home": "Hazatérés"
+    "cleaning": "Tisztítás",
+    "paused": "Szünet",
+    "idle": "Tétlen",
+    "charging": "Töltés",
+    "returning home": "Hazatérés"
   },
   "source": {
-    "Gentle": "Gyengéd",
-    "Silent": "Csendes",
-    "Standard": "Alap",
-    "Medium": "Közepes",
-    "Turbo": "Turbo"
+    "gentle": "Gyengéd",
+    "silent": "Csendes",
+    "standard": "Alap",
+    "medium": "Közepes",
+    "turbo": "Turbo"
   },
   "common": {
     "name": "Porszívó Kártya",

--- a/src/translations/it.json
+++ b/src/translations/it.json
@@ -1,10 +1,10 @@
 {
   "status": {
-    "Cleaning": "In pulizia",
-    "Paused": "In pausa",
-    "Idle": "Inattivo",
-    "Charging": "In carica",
-    "Returning home": "In rientro alla base"
+    "cleaning": "In pulizia",
+    "paused": "In pausa",
+    "idle": "Inattivo",
+    "charging": "In carica",
+    "returning home": "In rientro alla base"
   },
   "common": {
     "name": "Vacuum Card",

--- a/src/translations/ko.json
+++ b/src/translations/ko.json
@@ -1,17 +1,17 @@
 {
   "status": {
-    "Cleaning": "청소중",
-    "Paused": "일시정지",
-    "Idle": "대기중",
-    "Charging": "충전중",
-    "Returning home": "복귀중"
+    "cleaning": "청소중",
+    "paused": "일시정지",
+    "idle": "대기중",
+    "charging": "충전중",
+    "returning home": "복귀중"
   },
   "source": {
-    "Gentle": "물걸레",
-    "Silent": "저소음",
-    "Standard": "밸런스",
-    "Medium": "터보",
-    "Turbo": "최강"
+    "gentle": "물걸레",
+    "silent": "저소음",
+    "standard": "밸런스",
+    "medium": "터보",
+    "turbo": "최강"
   },
   "common": {
     "name": "청소기 카드",

--- a/src/translations/nb.json
+++ b/src/translations/nb.json
@@ -1,18 +1,17 @@
-
 {
   "status": {
-    "Cleaning": "Rengjøring",
-    "Paused": "Pauset",
-    "Idle": "Tomgang",
-    "Charging": "Lader",
-    "Returning home": "Returnerer hjem"
+    "cleaning": "Rengjøring",
+    "paused": "Pauset",
+    "idle": "Tomgang",
+    "charging": "Lader",
+    "returning home": "Returnerer hjem"
   },
   "source": {
-    "Gentle": "Skånsom",
-    "Silent": "Stille",
-    "Standard": "Standard",
-    "Medium": "Medium",
-    "Turbo": "Turbo"
+    "gentle": "Skånsom",
+    "silent": "Stille",
+    "standard": "Standard",
+    "medium": "Medium",
+    "turbo": "Turbo"
   },
   "common": {
     "name": "Støvsuger kort",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -1,10 +1,10 @@
 {
   "status": {
-    "Cleaning": "Aan het schoonmaken",
-    "Paused": "Gepauzeerd",
-    "Idle": "Inactief",
-    "Charging": "Aan het opladen",
-    "Returning home": "Keert terug naar dock"
+    "cleaning": "Aan het schoonmaken",
+    "paused": "Gepauzeerd",
+    "idle": "Inactief",
+    "charging": "Aan het opladen",
+    "returning home": "Keert terug naar dock"
   },
   "common": {
     "name": "Stofzuiger kaart",

--- a/src/translations/pl.json
+++ b/src/translations/pl.json
@@ -1,10 +1,10 @@
 {
   "status": {
-    "Cleaning": "Sprzątanie",
-    "Paused": "Wstrzymany",
-    "Idle": "Bezczynny",
-    "Charging": "Ładowanie",
-    "Returning home": "Powrót do bazy"
+    "cleaning": "Sprzątanie",
+    "paused": "Wstrzymany",
+    "idle": "Bezczynny",
+    "charging": "Ładowanie",
+    "returning home": "Powrót do bazy"
   },
   "common": {
     "name": "Vacuum Card",

--- a/src/translations/pt.json
+++ b/src/translations/pt.json
@@ -1,17 +1,17 @@
 {
   "status": {
-    "Cleaning": "A Limpar",
-    "Paused": "Pausado",
-    "Idle": "Parado",
-    "Charging": "A Carregar",
-    "Returning home": "Voltar para a Base"
+    "cleaning": "A Limpar",
+    "paused": "Pausado",
+    "idle": "Parado",
+    "charging": "A Carregar",
+    "returning home": "Voltar para a Base"
   },
   "source": {
-    "Gentle": "Delicado",
-    "Silent": "Silencioso",
-    "Standard": "Standard",
-    "Medium": "Medio",
-    "Turbo": "Turbo"
+    "gentle": "Delicado",
+    "silent": "Silencioso",
+    "standard": "Standard",
+    "medium": "Medio",
+    "turbo": "Turbo"
   },
   "common": {
     "name": "Vacuum Card",

--- a/src/translations/ru.json
+++ b/src/translations/ru.json
@@ -1,19 +1,19 @@
 {
   "status": {
-    "Cleaning": "Убирает",
-    "Paused": "Пауза",
-    "Idle": "Ожидает",
-    "Charging": "Заряжается",
-    "Returning home": "Возвращается",
-    "Segment cleaning": "Уборка зоны/комнаты"
+    "cleaning": "Убирает",
+    "paused": "Пауза",
+    "idle": "Ожидает",
+    "charging": "Заряжается",
+    "returning home": "Возвращается",
+    "segment cleaning": "Уборка зоны/комнаты"
   },
   "source": {
-    "Gentle": "Деликатный",
-    "Silent": "Тихий",
-    "Standard": "Стандартный",
-    "Medium": "Средний",
-    "Turbo": "Турбо"
-  },  
+    "gentle": "Деликатный",
+    "silent": "Тихий",
+    "standard": "Стандартный",
+    "medium": "Средний",
+    "turbo": "Турбо"
+  },
   "common": {
     "name": "Пылесос",
     "description": "Карта \"пылесос\" позволяет управлять роботом-пылесосом.",
@@ -40,7 +40,7 @@
     "show_name_aria_label_off": "Скрыть название",
     "show_status": "Показать статус?",
     "show_status_aria_label_on": "Показать статус",
-    "show_status_aria_label_off": "Скрыть статус",	
+    "show_status_aria_label_off": "Скрыть статус",
     "show_toolbar": "Показать панель действий?",
     "show_toolbar_aria_label_on": "Показать панель действий",
     "show_toolbar_aria_label_off": "Скрыть панель действий",

--- a/src/translations/sv.json
+++ b/src/translations/sv.json
@@ -1,17 +1,17 @@
 {
   "status": {
-    "Cleaning": "Städar",
-    "Paused": "Pausad",
-    "Idle": "Inaktiv",
-    "Charging": "Laddar",
-    "Returning home": "Återvänder hem"
+    "cleaning": "Städar",
+    "paused": "Pausad",
+    "idle": "Inaktiv",
+    "charging": "Laddar",
+    "returning home": "Återvänder hem"
   },
   "source": {
-    "Gentle": "Extra försiktig",
-    "Silent": "Eco - tyst",
-    "Standard": "Standard",
-    "Medium": "Medium",
-    "Turbo": "Turbo"
+    "gentle": "Extra försiktig",
+    "silent": "Eco - tyst",
+    "standard": "Standard",
+    "medium": "Medium",
+    "turbo": "Turbo"
   },
   "common": {
     "name": "Dammsugarkort",

--- a/src/translations/uk.json
+++ b/src/translations/uk.json
@@ -1,18 +1,18 @@
 {
   "status": {
-    "Cleaning": "Прибирає",
-    "Paused": "Пауза",
-    "Idle": "Очікує",
-    "Charging": "Заряджається",
-    "Returning home": "Повертається",
-    "Segment cleaning": "Зоноване прибирання"
+    "cleaning": "Прибирає",
+    "paused": "Пауза",
+    "idle": "Очікує",
+    "charging": "Заряджається",
+    "returning home": "Повертається",
+    "segment cleaning": "Зоноване прибирання"
   },
   "source": {
-    "Gentle": "Делікатний",
-    "Silent": "Тихий",
-    "Standard": "Стандартний",
-    "Medium": "Середній",
-    "Turbo": "Турбо"
+    "gentle": "Делікатний",
+    "silent": "Тихий",
+    "standard": "Стандартний",
+    "medium": "Середній",
+    "turbo": "Турбо"
   },
   "common": {
     "name": "Пилосос",

--- a/src/vacuum-card.js
+++ b/src/vacuum-card.js
@@ -189,7 +189,7 @@ class VacuumCard extends LitElement {
     } = entity.attributes;
 
     return {
-      status: status || state,
+      status: status || state || entity.state,
       fan_speed,
       fan_speed_list,
       battery_level,


### PR DESCRIPTION
Hi @denysdovhan,

thanks for the amazing vacuum card. Some vacuums doesn't have a attribute status and therefore I add a fallback to the entity state. Fixes #154 

As the states in HA are loercase, I converted all translation keys to lowercase. In addition I lowercase the passed string in the `localize` method, so it works also for statuses which are not lowercase.

At the end add my vacuum to the list and fix a typo.

Enjoy the holidays and happy new year :fireworks: 