### PR TITLE
Add supported device Roborock S6 Pure

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ If this card works with your vacuum cleaner, please open a PR and your model to 
 
 - Roborock S6 MaxV
 - Roborock S6
+- Roborock S6 Pure
 - Roborock S5
 - Roborock S5 Max
 - Roborock S50


### PR DESCRIPTION
Checked on my Roborock S6 Pure (model: roborock.vacuum.a08, firmware: 3.5.8_0938). Vacuum cleaner does not seem to have mop sensor at all, so mop_attached attribute is always false.