### PR TITLE
Added states for Deebot N79; including auto, spot, and edge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Just search for `Vacuum Card` in plugins tab.
 2. Put `vacuum-card.js` file into your `config/www` folder.
 3. Add reference to `vacuum-card.js` in Lovelace. There's two way to do that:
    1. **Using UI:** _Configuration_ → _Lovelace Dashboards_ → _Resources Tab_ → Click Plus button → Set _Url_ as `/local/vacuum-card.js` → Set _Resource type_ as `JavaScript Module`.
-   **Note:** If you do not see the Resources Tab, you will need to enable _Advanced Mode_ in your _User Profile_
+      **Note:** If you do not see the Resources Tab, you will need to enable _Advanced Mode_ in your _User Profile_
    2. **Using YAML:** Add following code to `lovelace` section.
       ```yaml
       resources:
@@ -168,7 +168,7 @@ This card supports translations. Please, help to add more translations and impro
 - 한국어 (Korean)
 - Suomi (Finnish)
 - Català (Catalan)
-- 正體中文 (Traditional Chinese) 
+- 正體中文 (Traditional Chinese)
 - Việt Nam (Vietnamese)
 - [_Your language?_][add-translation]
 
@@ -192,7 +192,7 @@ If this card works with your vacuum cleaner, please open a PR and your model to 
 - Xiaomi Mi Robot (STYJ02YM)
 - Xiaomi Mi Robot 1S
 - Xiaomi Mi Roborock V1 (SDJQR02RR)
-- Xiaomi Mijia 1C 
+- Xiaomi Mijia 1C
 - Roomba 675
 - Roomba 960
 - Roomba 981
@@ -204,6 +204,7 @@ If this card works with your vacuum cleaner, please open a PR and your model to 
 - Shark IQ
 - Ecovacs Deebot 950
 - EcoVacs Deebot OZMO T8 AIVI
+- EcoVacs Deebot N79
 - Eufy Robovac 30c
 - Mi Robot Vacuum-Mop P
 - [_Your vacuum?_][edit-readme]

--- a/src/styles.js
+++ b/src/styles.js
@@ -110,8 +110,12 @@ export default css`
     margin: 30px auto 20px auto;
   }
 
+  .vacuum.on,
   .vacuum.cleaning,
-  .vacuum.on {
+  .vacuum.auto,
+  .vacuum.spot,
+  .vacuum.edge,
+  .vacuum.single_room {
     animation: cleaning 5s linear infinite;
   }
 
@@ -123,7 +127,8 @@ export default css`
     opacity: 100%;
   }
 
-  .vacuum.docked {
+  .vacuum.docked,
+  .vacuum.idle {
     opacity: 50%;
   }
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -127,8 +127,7 @@ export default css`
     opacity: 100%;
   }
 
-  .vacuum.docked,
-  .vacuum.idle {
+  .vacuum.docked {
     opacity: 50%;
   }
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -185,7 +185,7 @@ export default css`
     font-size: 16px;
   }
 
-  .not-available {
+  .not-available .offline {
     text-align: center;
     color: var(--text-primary-color);
     font-size: 16px;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -12,7 +12,8 @@
     "returning home": "Returning Home",
     "returning": "Returning Home",
     "docked": "Docked",
-    "unknown": "Unknown"
+    "unknown": "Unknown",
+    "offline": "Offline"
   },
   "source": {
     "gentle": "Gentle",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,18 +1,27 @@
 {
   "status": {
     "cleaning": "Cleaning",
+    "auto": "Automatic Cleaning",
+    "spot": "Spot Cleaning",
+    "edge": "Edge Cleaning",
+    "single_room": "Single Room Cleaning",
     "paused": "Paused",
     "idle": "Idle",
+    "stop": "Stopped",
     "charging": "Charging",
-    "returning home": "Returning home",
-    "docked": "Docked"
+    "returning home": "Returning Home",
+    "returning": "Returning Home",
+    "docked": "Docked",
+    "unknown": "Unknown"
   },
   "source": {
     "gentle": "Gentle",
     "silent": "Silent",
     "standard": "Standard",
     "medium": "Medium",
-    "turbo": "Turbo"
+    "turbo": "Turbo",
+    "normal": "Normal",
+    "high": "High"
   },
   "common": {
     "name": "Vacuum Card",
@@ -22,7 +31,7 @@
     "pause": "Pause",
     "stop": "Stop",
     "return_to_base": "Dock",
-    "locate": "Locate vacuum",
+    "locate": "Locate Vacuum",
     "not_available": "Vacuum is not available"
   },
   "error": {

--- a/src/vacuum-card.js
+++ b/src/vacuum-card.js
@@ -318,6 +318,9 @@ class VacuumCard extends LitElement {
 
     switch (state) {
       case 'on':
+      case 'auto':
+      case 'spot':
+      case 'edge':
       case 'cleaning': {
         return html`
           <div class="toolbar">

--- a/src/vacuum-card.js
+++ b/src/vacuum-card.js
@@ -321,6 +321,7 @@ class VacuumCard extends LitElement {
       case 'auto':
       case 'spot':
       case 'edge':
+      case 'single_room':
       case 'cleaning': {
         return html`
           <div class="toolbar">


### PR DESCRIPTION
I added extra support for my Deebot N79 with cleaning states "auto", "spot", and "edge". These are subsets of the 'cleaning' state and the card didn't adjust to these properly. This PR fixes that.