### PR TITLE
Fix `getCardSize()`

### DIFF
--- a/src/vacuum-card.js
+++ b/src/vacuum-card.js
@@ -100,7 +100,7 @@ class VacuumCard extends LitElement {
   }
 
   getCardSize() {
-    return 2;
+    return this.config.compact_view || false ? 2 : 8;
   }
 
   shouldUpdate(changedProps) {

--- a/src/vacuum-card.js
+++ b/src/vacuum-card.js
@@ -100,7 +100,7 @@ class VacuumCard extends LitElement {
   }
 
   getCardSize() {
-    return this.config.compact_view || false ? 2 : 8;
+    return this.config.compact_view || false ? 3 : 8;
   }
 
   shouldUpdate(changedProps) {


### PR DESCRIPTION
`getCardSize()` shouldn't return **2** here [docs](https://developers.home-assistant.io/docs/frontend/custom-ui/lovelace-custom-card/#api). This card is 399px normally so it should return **8** and 159 in compact so it should return **3**.