### PR TITLE
Add image-rendering optimize-contrast in map

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -30,6 +30,7 @@ export default css`
 
   .map {
     max-width: 95%;
+    image-rendering: -webkit-optimize-contrast;
     image-rendering: crisp-edges;
   }
 


### PR DESCRIPTION
Hello! 

This small PR will add `image-rendering: -webkit-optimize-contrast` for webkit based browsers, that not supported `crisp-edges` (Chrome, Opera, etc.). This will help get rid of the blur in map.

[Can i use](https://caniuse.com/?search=crisp-edges).

**Comparing (Chrome):**

Before:

![chrome_2021-06-07_16-41-14](https://user-images.githubusercontent.com/11841379/121027054-57224500-c7af-11eb-98ab-760ae3fe223f.png)

After:

![chrome_2021-06-07_16-41-45](https://user-images.githubusercontent.com/11841379/121027059-57badb80-c7af-11eb-84ca-79912735cba1.png)
