### PR TITLE
WIP: Feature/add mop attributes

### DIFF
--- a/src/vacuum-card.js
+++ b/src/vacuum-card.js
@@ -505,12 +505,12 @@ class VacuumCard extends LitElement {
   }
 }
 
-customElements.define('nwh-vacuum-card', VacuumCard);
+customElements.define('vacuum-card', VacuumCard);
 
 window.customCards = window.customCards || [];
 window.customCards.push({
   preview: true,
-  type: 'nwh-vacuum-card',
+  type: 'vacuum-card',
   name: localize('common.name'),
   description: localize('common.description'),
 });


### PR DESCRIPTION
Fixes https://github.com/denysdovhan/vacuum-card/issues/236

Looking for suggestions from maintainers/contributors, haven't done JS/web in years so I'm sure quality can be improved. There's some unused properties but I'm not sure all of them need to be used.

Changes:

- Changes the 'source' (which was fan speed) to show the mop settings, a mixture of spray amount and coverage type
- The mdi icon changes to `mdi:water` for a wet pad, `mdi:water-off` for a dry pad, and `mdi:water-remove-outline` if water is empty.

I didn't add the localization, since the contributor guidelines specify only native speakers can add them. Probably for the best.