### PR TITLE
add water level

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Here is what every option means:
 | `stats`        | `object`  | Optional     | Custom per state stats for your vacuum cleaner                                                            |
 | `actions`      | `object`  | Optional     | Override default actions behavior with service invocations.                                               |
 | `shortcuts`    | `object`  | Optional     | List of shortcuts shown at the right bottom part of the card with custom actions for your vacuum cleaner. |
+| `water_level`  | `string`  | Optional     | An entity_id within the `select` domain, for showing/setting the water level of the vacuum.               |
 
 ### `stats` object
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -965,6 +965,14 @@
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+          "dev": true
+        }
       }
     },
     "argv-formatter": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "custom-card-helpers": "^1.6.4",
     "lit-element": "^2.3.1",
-    "lodash.get": "^4.4.2"
+    "lodash.get": "^4.4.2",
+    "typescript-string-operations": "^1.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.9.6",

--- a/src/styles.js
+++ b/src/styles.js
@@ -151,7 +151,7 @@ export default css`
     padding: 8px;
   }
 
-  .source {
+  .drop-down {
     text-align: center;
   }
 

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -16,6 +16,12 @@
     "medium": "Mittel",
     "turbo": "Max."
   },
+  "water_level": {
+    "low": "Niedrig",
+    "medium": "Mittel",
+    "high": "Hoch",
+    "ultrahigh": "Sehr hoch"
+  },
   "common": {
     "name": "Vacuum Card",
     "description": "Vacuum card ermöglicht es Ihnen, Ihr Staubsaugerroboter zu steuern.",
@@ -27,7 +33,8 @@
     "locate": "Staubsauger lokalisieren"
   },
   "error": {
-    "missing_entity": "Angabe der Entität ist erforderlich!"
+    "missing_entity": "Angabe der Entität ist erforderlich!",
+    "domain_not_supported": "Domain nicht unterstützt!  Erfoderlich ist {0}, aber Sie haben {1} angegeben!"
   },
   "warning": {
     "actions_array": ""
@@ -35,6 +42,7 @@
   "editor": {
     "entity": "Entität (Erforderlich)",
     "map": "Map Camera (Optional)",
+    "water_level": "Wasser Level Select (Optional)",
     "image": "Bild (Optional)",
     "compact_view": "kompakte Ansicht",
     "compact_view_aria_label_on": "Schalte kompakte Ansicht ein",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -26,6 +26,12 @@
     "high": "High",
     "strong": "Strong"
   },
+  "water_level": {
+    "low": "Low",
+    "medium": "Medium",
+    "high": "High",
+    "ultrahigh": "Ultrahigh"
+  },
   "common": {
     "name": "Vacuum Card",
     "description": "Vacuum card allows you to control your robot vacuum.",
@@ -38,7 +44,8 @@
     "not_available": "Vacuum is not available"
   },
   "error": {
-    "missing_entity": "Specifying entity is required!"
+    "missing_entity": "Specifying entity is required!",
+    "domain_not_supported": "Domain not supported! Required is {0}, but you specified {1}!"
   },
   "warning": {
     "actions_array": "WARNING: 'actions' is reserved to override default actions for existing buttons. If your intention was to add additional actions, use the 'shortcuts' option instead."
@@ -46,6 +53,7 @@
   "editor": {
     "entity": "Entity (Required)",
     "map": "Map Camera (Optional)",
+    "water_level": "Water Level Select (Optional)",
     "image": "Image (Optional)",
     "compact_view": "Compact View",
     "compact_view_aria_label_on": "Toggle compact view on",

--- a/src/vacuum-card-editor.js
+++ b/src/vacuum-card-editor.js
@@ -36,6 +36,14 @@ export class VacuumCardEditor extends LitElement {
     return '';
   }
 
+  get _water_level() {
+    if (this._config) {
+      return this._config.water_level || '';
+    }
+
+    return '';
+  }
+
   get _image() {
     if (this._config) {
       return this._config.image || '';
@@ -82,6 +90,25 @@ export class VacuumCardEditor extends LitElement {
     );
   }
 
+  renderDropDownMenu(configValue, selectedEntity, entities) {
+    return html`
+      <paper-dropdown-menu
+        label="${localize('editor.' + configValue)}"
+        @value-changed=${this._valueChanged}
+        .configValue=${configValue}
+      >
+        <paper-listbox
+          slot="dropdown-content"
+          .selected=${entities.indexOf(selectedEntity)}
+        >
+          ${entities.map((entity) => {
+            return html` <paper-item>${entity}</paper-item> `;
+          })}
+        </paper-listbox>
+      </paper-dropdown-menu>
+    `;
+  }
+
   render() {
     if (!this.hass) {
       return html``;
@@ -89,38 +116,17 @@ export class VacuumCardEditor extends LitElement {
 
     const vacuumEntities = this.getEntitiesByType('vacuum');
     const cameraEntities = this.getEntitiesByType('camera');
+    const selectEntities = this.getEntitiesByType('select');
 
     return html`
       <div class="card-config">
-        <paper-dropdown-menu
-          label="${localize('editor.entity')}"
-          @value-changed=${this._valueChanged}
-          .configValue=${'entity'}
-        >
-          <paper-listbox
-            slot="dropdown-content"
-            .selected=${vacuumEntities.indexOf(this._entity)}
-          >
-            ${vacuumEntities.map((entity) => {
-              return html` <paper-item>${entity}</paper-item> `;
-            })}
-          </paper-listbox>
-        </paper-dropdown-menu>
-
-        <paper-dropdown-menu
-          label="${localize('editor.entity')}"
-          @value-changed=${this._valueChanged}
-          .configValue=${'map'}
-        >
-          <paper-listbox
-            slot="dropdown-content"
-            .selected=${cameraEntities.indexOf(this._map)}
-          >
-            ${cameraEntities.map((entity) => {
-              return html` <paper-item>${entity}</paper-item> `;
-            })}
-          </paper-listbox>
-        </paper-dropdown-menu>
+        ${this.renderDropDownMenu('entity', this._entity, vacuumEntities)}
+        ${this.renderDropDownMenu('map', this._map, cameraEntities)}
+        ${this.renderDropDownMenu(
+          'water_level',
+          this._water_level,
+          selectEntities
+        )}
 
         <paper-input
           label="${localize('editor.image')}"

--- a/src/vacuum-card.js
+++ b/src/vacuum-card.js
@@ -183,15 +183,15 @@ class VacuumCard extends LitElement {
     );
   }
 
-  handleSpeed(e) {
+  handleSpeed(e, context) {
     const fan_speed = e.target.getAttribute('value');
-    this.callService('set_fan_speed', false, { fan_speed });
+    context.callService('set_fan_speed', false, { fan_speed });
   }
 
-  handleSelect(e) {
+  handleSelect(e, context) {
     const value = e.target.getAttribute('value');
-    this.hass.callService('select', 'select_option', {
-      entity_id: this.waterLevel.entity_id,
+    context.hass.callService('select', 'select_option', {
+      entity_id: context.waterLevel.entity_id,
       option: value,
     });
   }
@@ -357,7 +357,7 @@ class VacuumCard extends LitElement {
         <paper-listbox
           slot="dropdown-content"
           selected=${selected}
-          @click="${(e) => onSelected(e)}"
+          @click="${(e) => onSelected(e, this)}"
         >
           ${objects.map(
             (item) =>

--- a/src/vacuum-card.js
+++ b/src/vacuum-card.js
@@ -100,7 +100,7 @@ class VacuumCard extends LitElement {
     return this.config.compact_view;
   }
 
-  get waterLevel() {
+  get waterLevelEntity() {
     if (!this.hass || !this.config.water_level) {
       return null;
     }
@@ -117,7 +117,11 @@ class VacuumCard extends LitElement {
       );
     }
 
-    return this.hass.states[waterLevel];
+    return waterLevel;
+  }
+
+  get waterLevel() {
+    return this.hass.states[this.waterLevelEntity];
   }
 
   setConfig(config) {
@@ -137,8 +141,18 @@ class VacuumCard extends LitElement {
     return this.config.compact_view || false ? 3 : 8;
   }
 
+  hasWaterLevelChanged(changedProps) {
+    return (
+      changedProps.get('hass').states[this.waterLevelEntity].state !==
+      this.waterLevel.state
+    );
+  }
+
   shouldUpdate(changedProps) {
-    return hasConfigOrEntityChanged(this, changedProps);
+    return (
+      hasConfigOrEntityChanged(this, changedProps) ||
+      this.hasWaterLevelChanged(changedProps)
+    );
   }
 
   updated(changedProps) {


### PR DESCRIPTION
Add a drop down menu for the water level:
![grafik](https://user-images.githubusercontent.com/26537646/144420255-bb0e5593-738c-4198-8219-6380b9b5e6a4.png)

As the water level is not part of the vacuum entity at least not specified by Home Assistant.
I implemented it for `select` entities as the [Deebot 4 Home Assistant](https://github.com/DeebotUniverse/Deebot-4-Home-Assistant) integration is provided this information as `select` entity.