### PR TITLE
update fan speed translations for deebot vacuums

### DIFF
--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -12,9 +12,11 @@
   },
   "source": {
     "silent": "Leise",
-    "standard": "Normal",
     "medium": "Mittel",
-    "turbo": "Max."
+    "turbo": "Max.",
+    "quiet": "Leise",
+    "max": "Maximal",
+    "max+": "Maximal+"
   },
   "common": {
     "name": "Vacuum Card",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -24,7 +24,10 @@
     "turbo": "Turbo",
     "normal": "Normal",
     "high": "High",
-    "strong": "Strong"
+    "strong": "Strong",
+    "quiet": "Quiet",
+    "max": "Max",
+    "max+": "Max+"
   },
   "common": {
     "name": "Vacuum Card",


### PR DESCRIPTION
In addition I removed the fan speed "standard" in the german translation, so it will fallback to the english specified value.
Standard means also in german standard and the same is for normal.
