### PR TITLE
fix #322. Adding conversion rate and rounding changing displayed units.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ You can use any attribute of vacuum or even any entity by `entity_id` to display
 | `attribute` | `string` | Optional | Attribute name of the stat, i.e. `filter_left`. |
 | `unit`      | `string` | Optional | Unit of measure, i.e. `hours`.                  |
 | `subtitle`  | `string` | Optional | Friendly name of the stat, i.e. `Filter`.       |
+| `conversion`| `number` | Optional | A factor to divide the current value by when displaying. (Can be `3600` if the platform provides times in seconds and we need them displayed in hours)|
+| `rounding`| `number` | Optional | The number of decimal points used when displaying the value|
 
 ### `actions` object
 

--- a/src/vacuum-card.js
+++ b/src/vacuum-card.js
@@ -323,12 +323,24 @@ class VacuumCard extends LitElement {
     return nothing;
   }
 
+  formatValue(value, conversion, rounding){
+    if (conversion && !isNaN(conversion)) {          
+      value = value / conversion;
+    }
+
+    if (!isNaN(rounding)) {      
+      return value.toFixed(rounding)
+    }
+
+    return value;
+  }
+
   renderStats(state) {
     const { stats = {} } = this.config;
 
     const statsList = stats[state] || stats.default || [];
 
-    return statsList.map(({ entity_id, attribute, unit, subtitle }) => {
+    return statsList.map(({ entity_id, attribute, unit, subtitle, conversion, rounding }) => {
       if (!entity_id && !attribute) {
         return nothing;
       }
@@ -336,10 +348,12 @@ class VacuumCard extends LitElement {
       const value = entity_id
         ? this.hass.states[entity_id].state
         : get(this.entity.attributes, attribute);
+        
+   
 
       return html`
         <div class="stats-block">
-          <span class="stats-value">${value}</span>
+          <span class="stats-value">${this.formatValue(value, conversion, rounding)}</span>
           ${unit}
           <div class="stats-subtitle">${subtitle}</div>
         </div>


### PR DESCRIPTION
The Xiaomi platform has recently been changed to provide time values in seconds, which are directly displayed as such on the card. (See issue #322 )
This PR provides a way to optionally convert the value before displaying it. 