### PR TITLE
Fix hovering labels for ha-icon-buttons

### DIFF
--- a/src/vacuum-card.js
+++ b/src/vacuum-card.js
@@ -451,7 +451,7 @@ class VacuumCard extends LitElement {
               this.callAction({ service, service_data });
             };
             return html`
-              <ha-icon-button title="${name}" @click="${execute}">
+              <ha-icon-button label="${name}" @click="${execute}">
                 <ha-icon icon="${icon}"></ha-icon>
               </ha-icon-button>
             `;
@@ -460,7 +460,7 @@ class VacuumCard extends LitElement {
 
         const dockButton = html`
           <ha-icon-button
-            title="${localize('common.return_to_base')}"
+            label="${localize('common.return_to_base')}"
             @click="${this.handleAction('return_to_base')}"
             ><ha-icon icon="hass:home-map-marker"></ha-icon>
           </ha-icon-button>
@@ -469,13 +469,13 @@ class VacuumCard extends LitElement {
         return html`
           <div class="toolbar">
             <ha-icon-button
-              title="${localize('common.start')}"
+              label="${localize('common.start')}"
               @click="${this.handleAction('start')}"
               ><ha-icon icon="hass:play"></ha-icon>
             </ha-icon-button>
 
             <ha-icon-button
-              title="${localize('common.locate')}"
+              label="${localize('common.locate')}"
               @click="${this.handleAction('locate', { isRequest: false })}"
               ><ha-icon icon="mdi:map-marker"></ha-icon>
             </ha-icon-button>


### PR DESCRIPTION
Hi. I found your project very exciting during my upgrade & rewrite of my homeassistant setup. I'm just migrating over some shortcuts from my previous setup and found that it's hard to tell what the shortcut is doing by just looking at it.

While checking the code if [ha-icon-button](https://github.com/home-assistant/frontend/blob/28f1b6bdf44ad14cd09ac429e1bc7628fd338599/src/components/ha-icon-button.ts#L28) I realized we're using `title` instead of `label` to add hover text, so I replaced them in the code.

Here's an image of the working hover-texts:

![image](https://user-images.githubusercontent.com/1900366/164972548-fc771751-c9b2-44f4-9332-d11dd35b9222.png)

I'm using:
* Firefox 99 / Chrome 100
* Home Assistant 2022.4.6