### PR TITLE
Update it.json

### DIFF
--- a/src/translations/it.json
+++ b/src/translations/it.json
@@ -4,8 +4,8 @@
     "paused": "In pausa",
     "idle": "Inattivo",
     "charging": "In carica",
-    "returning home": "In rientro alla base",
-    "docked": "In Base"
+    "returning_home": "In rientro alla base",
+    "docked": "Alla Base"
   },
   "source": {
     "gentle": "Gentile",
@@ -23,7 +23,7 @@
     "stop": "Stop",
     "return_to_base": "Base",
     "locate": "Trova aspirapolvere",
-    "not_available": "Vacuum non disponibile"
+    "not_available": "Aspirapolvere non disponibile"
   },
   "error": {
     "missing_entity": "È necessario specificare l'entità!"


### PR DESCRIPTION
Fixed returning_home not formatted correctly (underscore was missing), making it show the english version 
Fixed docked from "In Base" to "Alla Base", which is better in Italian 
Fixed not_available from "vacuum non disponibile" to "Aspirapolvere non disponibile"