### PR TITLE
Add Roborock Qrevo to README list of vacuums

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ This card relies on basic vacuum services, like `pause`, `start`, `stop`, `retur
 
 If this card works with your vacuum cleaner, please open a PR and your model to the list.
 
-- **Roborock** S8 (Ultra Pro), S7 (MaxV), S6 (MaxV, Pure), S5 (Max), S50, S4 (Max), E25, E4, Q5 Pro
+- **Roborock** S8 (Ultra Pro), S7 (MaxV), S6 (MaxV, Pure), S5 (Max), S50, S4 (Max), E25, E4, Q5 Pro, Qrevo
 - **Mijia** Robot Vacuum Cleaner 1C (STYTJ01ZHM)
 - **Xiaomi** Mi Robot (STYJ02YM), Mi Robot 1S, Mi Roborock V1 (SDJQR02RR), Mijia 1C, Mi Robot Vacuum-Mop P, Robot Vacuum E10
 - **Roomba** 670, 675, 676, 960980, 981, i3, i7+, e5, S9, s9+, j7


### PR DESCRIPTION
Confirmed working on my unit. _Qrevo_ appears to be the spelling used in https://us.roborock.com/pages/roborock-q-revo.