### PR TITLE
Add remaining mop drying time

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Here is what every option means:
 | `stats`        | `object`  | Optional     | Custom per state stats for your vacuum cleaner                                                            |
 | `actions`      | `object`  | Optional     | Override default actions behavior with service invocations.                                               |
 | `shortcuts`    |  `array`  | Optional     | List of shortcuts shown at the right bottom part of the card with custom actions for your vacuum cleaner. |
+| `mop_drying`   | `object`  | Optional     | A `stats` Object with an entity or attribute for the duration of remaining mop drying.                    |
 
 ### `stats` object
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26223,6 +26223,14 @@
       "requires": {
         "mime": "^4",
         "opener": "1"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+          "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+          "dev": true
+        }
       }
     },
     "rollup-plugin-typescript2": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,5 +29,6 @@ export default function buildConfig(
     stats: config.stats ?? {},
     actions: config.actions ?? {},
     shortcuts: config.shortcuts ?? [],
+    mop_drying: config.mop_drying ?? {},
   };
 }

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -75,6 +75,6 @@
     "show_toolbar": "Zeige Toolbar",
     "show_toolbar_aria_label_on": "Schalte 'Zeige Toolbar' ein",
     "show_toolbar_aria_label_off": "Schalte 'Zeige Toolbar' aus",
-    "code_only_note": "Hinweis: Das Festlegen von Aktionen und Statistikoptionen ist ausschließlich mit dem Code-Editor möglich."
+    "code_only_note": "Hinweis: Das Festlegen von Aktionen, Statistikoptionen und Mop Trocknung ist ausschließlich mit dem Code-Editor möglich."
   }
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -75,6 +75,6 @@
     "show_toolbar": "Show Toolbar",
     "show_toolbar_aria_label_on": "Toggle display toolbar on",
     "show_toolbar_aria_label_off": "Toggle display toolbar off",
-    "code_only_note": "Note: Setting actions and stats options are available exclusively using Code Editor."
+    "code_only_note": "Note: Setting actions, stats and mop drying options are available exclusively using Code Editor."
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,7 @@ export interface VacuumCardConfig {
   stats: Record<string, VacuumCardStat[]>;
   actions: Record<string, VacuumCardAction>;
   shortcuts: VacuumCardShortcut[];
+  mop_drying: VacuumCardStat;
 }
 
 export interface VacuumServiceCallParams {

--- a/src/vacuum-card.ts
+++ b/src/vacuum-card.ts
@@ -20,7 +20,6 @@ import {
   VacuumEntityState,
   VacuumServiceCallParams,
   VacuumActionParams,
-  VacuumCardStat,
 } from './types';
 import DEFAULT_IMAGE from './vacuum.svg';
 
@@ -260,30 +259,43 @@ export class VacuumCard extends LitElement {
   private renderStats(state: VacuumEntityState): Template {
     const mop_drying = this.config.mop_drying;
 
+    const renderStatBlock = (
+      entity_id: string | undefined,
+      value_template: string | undefined,
+      value: string | number,
+      unit: string | undefined,
+      subtitle: string | undefined,
+    ) => {
+      const valueHtml = html`
+        <ha-template
+          hass=${this.hass}
+          template=${value_template}
+          value=${value}
+          variables=${{ value: value }}
+        ></ha-template>
+      `;
+
+      return html`
+        <div class="stats-block" @click="${() => this.handleMore(entity_id)}">
+          <span class="stats-value">${valueHtml}</span>
+          ${unit}
+          <div class="stats-subtitle">${subtitle}</div>
+        </div>
+      `;
+    };
+
     if (mop_drying.entity_id) {
       const remaining = parseFloat(
         this.hass.states[mop_drying.entity_id].state,
       );
       if (remaining !== 0) {
-        const value = html`
-          <ha-template
-            hass=${this.hass}
-            template=${mop_drying.value_template}
-            value=${remaining}
-            variables=${{ value: remaining }}
-          ></ha-template>
-        `;
-
-        return html`
-          <div
-            class="stats-block"
-            @click="${() => this.handleMore(mop_drying.entity_id)}"
-          >
-            <span class="stats-value">${value}</span>
-            ${mop_drying.unit}
-            <div class="stats-subtitle">${mop_drying.subtitle}</div>
-          </div>
-        `;
+        return renderStatBlock(
+          mop_drying.entity_id,
+          mop_drying.value_template,
+          remaining,
+          mop_drying.unit,
+          mop_drying.subtitle,
+        );
       }
     }
 
@@ -308,22 +320,13 @@ export class VacuumCard extends LitElement {
           return nothing;
         }
 
-        const value = html`
-          <ha-template
-            hass=${this.hass}
-            template=${value_template}
-            value=${state}
-            variables=${{ value: state }}
-          ></ha-template>
-        `;
-
-        return html`
-          <div class="stats-block" @click="${() => this.handleMore(entity_id)}">
-            <span class="stats-value">${value}</span>
-            ${unit}
-            <div class="stats-subtitle">${subtitle}</div>
-          </div>
-        `;
+        return renderStatBlock(
+          entity_id,
+          value_template,
+          state,
+          unit,
+          subtitle,
+        );
       },
     );
 

--- a/src/vacuum-card.ts
+++ b/src/vacuum-card.ts
@@ -20,6 +20,7 @@ import {
   VacuumEntityState,
   VacuumServiceCallParams,
   VacuumActionParams,
+  VacuumCardStat,
 } from './types';
 import DEFAULT_IMAGE from './vacuum.svg';
 
@@ -257,6 +258,35 @@ export class VacuumCard extends LitElement {
   }
 
   private renderStats(state: VacuumEntityState): Template {
+    const mop_drying = this.config.mop_drying;
+
+    if (mop_drying.entity_id) {
+      const remaining = parseFloat(
+        this.hass.states[mop_drying.entity_id].state,
+      );
+      if (remaining !== 0) {
+        const value = html`
+          <ha-template
+            hass=${this.hass}
+            template=${mop_drying.value_template}
+            value=${remaining}
+            variables=${{ value: remaining }}
+          ></ha-template>
+        `;
+
+        return html`
+          <div
+            class="stats-block"
+            @click="${() => this.handleMore(mop_drying.entity_id)}"
+          >
+            <span class="stats-value">${value}</span>
+            ${mop_drying.unit}
+            <div class="stats-subtitle">${mop_drying.subtitle}</div>
+          </div>
+        `;
+      }
+    }
+
     const statsList =
       this.config.stats[state] || this.config.stats.default || [];
 


### PR DESCRIPTION
Adds a stat for remaining mop drying time.

Configuration:
```
mop_drying:
  entity_id: sensor.roborock_q_revo_mop_drying_remaining_time
  value_template: "{{ value | round(2) }}"
  unit: h
  subtitle: Mop drying remaining
```

<img width="258" alt="image" src="https://github.com/user-attachments/assets/b569d85d-f324-4fab-898b-ab40d07f7a93" />

