### PR TITLE
Translation: Fix pt-BR translation

### DIFF
--- a/src/localize.ts
+++ b/src/localize.ts
@@ -85,7 +85,8 @@ export default function localize(
 
   const lang = (langStored || navigator.language.split('-')[0] || DEFAULT_LANG)
     .replace(/['"]+/g, '')
-    .replace('-', '_');
+    .replace('-', '_')
+    .toLowerCase();
 
   let translated: string | undefined;
 


### PR DESCRIPTION
Just fixing the `pt-BR` translation.

The return for `localStorage.getItem('selectedLanguage')` is `pt-BR`, but the language applies it as `pt_br`, so it's necessary to lower case it. 