### PR TITLE
Add language, stats thresholds, and ha_ripple config options

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,8 @@ export default function buildConfig(
     map: config.map ?? '',
     map_refresh: config.map_refresh ?? 5,
     image: config.image ?? 'default',
+    language: config.language ?? '',
+    ha_ripple: config.ha_ripple ?? false,
     show_name: config.show_name ?? true,
     show_status: config.show_status ?? true,
     show_toolbar: config.show_toolbar ?? true,

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -70,8 +70,8 @@ export class VacuumCardEditor extends LitElement implements LovelaceCardEditor {
           >
             ${vacuumEntities.map(
               (entity) =>
-                html` <mwc-list-item .value=${entity}
-                  >${entity}</mwc-list-item
+                html` <ha-list-item .value=${entity}
+                  >${entity}</ha-list-item
                 >`,
             )}
           </ha-select>
@@ -89,8 +89,8 @@ export class VacuumCardEditor extends LitElement implements LovelaceCardEditor {
           >
             ${batteryEntities.map(
               (entity) =>
-                html` <mwc-list-item .value=${entity}
-                  >${entity}</mwc-list-item
+                html` <ha-list-item .value=${entity}
+                  >${entity}</ha-list-item
                 >`,
             )}
           </ha-select>
@@ -108,20 +108,20 @@ export class VacuumCardEditor extends LitElement implements LovelaceCardEditor {
           >
             ${cameraEntities.map(
               (entity) =>
-                html` <mwc-list-item .value=${entity}
-                  >${entity}</mwc-list-item
+                html` <ha-list-item .value=${entity}
+                  >${entity}</ha-list-item
                 >`,
             )}
           </ha-select>
         </div>
 
         <div class="option">
-          <paper-input
+          <ha-textfield
             label="${localize('editor.image')}"
             .value=${this.image}
             .configValue=${'image'}
-            @value-changed=${this.valueChanged}
-          ></paper-input>
+            @change=${this.valueChanged}
+          ></ha-textfield>
         </div>
 
         <div class="option">

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -26,6 +26,7 @@ import * as pt_br from './translations/pt-BR.json';
 import * as ro from './translations/ro.json';
 import * as ru from './translations/ru.json';
 import * as sv from './translations/sv.json';
+import * as tr from './translations/tr.json';
 import * as tw from './translations/tw.json';
 import * as uk from './translations/uk.json';
 import * as vi from './translations/vi.json';
@@ -62,6 +63,7 @@ const languages: Record<string, Translations> = {
   ro,
   ru,
   sv,
+  tr,
   tw,
   uk,
   vi,
@@ -74,21 +76,28 @@ export default function localize(
   str: string,
   search?: string,
   replace?: string,
+  forceLang?: string,
 ): string | undefined {
   const [section, key] = str.toLowerCase().split('.');
 
-  let langStored: string | null = null;
+  let lang: string;
 
-  try {
-    langStored = JSON.parse(localStorage.getItem('selectedLanguage') ?? '');
-  } catch {
-    langStored = localStorage.getItem('selectedLanguage');
+  if (forceLang) {
+    lang = forceLang.replace('-', '_').toLowerCase();
+  } else {
+    let langStored: string | null = null;
+
+    try {
+      langStored = JSON.parse(localStorage.getItem('selectedLanguage') ?? '');
+    } catch {
+      langStored = localStorage.getItem('selectedLanguage');
+    }
+
+    lang = (langStored || navigator.language.split('-')[0] || DEFAULT_LANG)
+      .replace(/['"]+/g, '')
+      .replace('-', '_')
+      .toLowerCase();
   }
-
-  const lang = (langStored || navigator.language.split('-')[0] || DEFAULT_LANG)
-    .replace(/['"]+/g, '')
-    .replace('-', '_')
-    .toLowerCase();
 
   let translated: string | undefined;
 

--- a/src/translations/tr.json
+++ b/src/translations/tr.json
@@ -1,0 +1,82 @@
+{
+  "status": {
+    "cleaning": "Temizliyor",
+    "auto": "Otomatik temizlik",
+    "spot": "Nokta temizliği",
+    "edge": "Kenar temizliği",
+    "single_room": "Tek oda temizliği",
+    "paused": "Duraklatıldı",
+    "idle": "Boşta",
+    "stop": "Durduruldu",
+    "charging": "Şarj Oluyor",
+    "returning": "İstasyona Dönüyor",
+    "returning_home": "İstasyona Dönüyor",
+    "docked": "İstasyonda",
+    "unknown": "Bilinmiyor",
+    "offline": "Çevrimdışı",
+    "error": "Hata",
+    "charger_disconnected": "Şarj bağlantısı kesildi",
+    "remote_control_active": "Uzaktan kontrol aktif",
+    "manual_mode": "Manuel mod",
+    "shutting_down": "Kapatılıyor",
+    "updating": "Güncelleniyor",
+    "waiting": "Bekliyor",
+    "going_to_target": "Hedefe Gidiyor",
+    "zoned_cleaning": "Bölge temizliği",
+    "segment_cleaning": "Oda Temizliği"
+  },
+  "source": {
+    "gentle": "Nazik",
+    "silent": "Sessiz",
+    "standard": "Standart",
+    "medium": "Orta",
+    "turbo": "Turbo",
+    "normal": "Normal",
+    "max": "Maksimum",
+    "max_plus": "Maksimum+",
+    "high": "Yüksek",
+    "strong": "Güçlü",
+    "quiet": "Sessiz",
+    "auto": "Otomatik",
+    "balanced": "Dengeli",
+    "custom": "Özel",
+    "off": "Kapalı"
+  },
+  "common": {
+    "name": "Süpürge Kartı",
+    "description": "Süpürge kartı, robot süpürgenizi kontrol etmenizi sağlar.",
+    "start": "Temizle",
+    "continue": "Devam et",
+    "pause": "Duraklat",
+    "stop": "Durdur",
+    "return_to_base": "İstasyona dön",
+    "locate": "Süpürgeyi bul",
+    "not_available": "Süpürge kullanılamıyor"
+  },
+  "error": {
+    "invalid_config": "Geçersiz yapılandırma",
+    "missing_entity": "Varlık belirtmek zorunludur!"
+  },
+  "warning": {
+    "actions_array": "UYARI: 'actions' mevcut düğmeler için varsayılan eylemleri geçersiz kılmak üzere ayrılmıştır. Amacınız ek eylemler eklemekse, bunun yerine 'shortcuts' seçeneğini kullanın."
+  },
+  "editor": {
+    "entity": "Varlık (Zorunlu)",
+    "battery_entity": "Pil Varlığı (İsteğe bağlı)",
+    "map": "Harita Kamerası (İsteğe bağlı)",
+    "image": "Görsel (İsteğe bağlı)",
+    "compact_view": "Kompakt Görünüm",
+    "compact_view_aria_label_on": "Kompakt görünümü aç",
+    "compact_view_aria_label_off": "Kompakt görünümü kapat",
+    "show_name": "Adı Göster",
+    "show_name_aria_label_on": "Ad gösterimini aç",
+    "show_name_aria_label_off": "Ad gösterimini kapat",
+    "show_status": "Durumu Göster",
+    "show_status_aria_label_on": "Durum gösterimini aç",
+    "show_status_aria_label_off": "Durum gösterimini kapat",
+    "show_toolbar": "Araç Çubuğunu Göster",
+    "show_toolbar_aria_label_on": "Araç çubuğu gösterimini aç",
+    "show_toolbar_aria_label_off": "Araç çubuğu gösterimini kapat",
+    "code_only_note": "Not: Eylemler ve istatistik seçenekleri yalnızca Kod Düzenleyici kullanılarak ayarlanabilir."
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,12 +38,18 @@ export interface VacuumBatteryEntity extends HassEntityBase {
   attributes: HassEntityAttributeBase;
 }
 
+export interface VacuumCardStatThreshold {
+  value: number;
+  color: string;
+}
+
 export interface VacuumCardStat {
   entity_id?: string;
   attribute?: string;
   value_template?: string;
   unit?: string;
   subtitle?: string;
+  thresholds?: VacuumCardStatThreshold[];
 }
 
 export interface VacuumCardAction {
@@ -66,6 +72,8 @@ export interface VacuumCardConfig {
   map: string;
   map_refresh: number;
   image: string;
+  language: string;
+  ha_ripple: boolean;
   show_name: boolean;
   show_status: boolean;
   show_toolbar: boolean;

--- a/src/vacuum-card.ts
+++ b/src/vacuum-card.ts
@@ -71,6 +71,10 @@ export class VacuumCard extends LitElement {
     };
   }
 
+  private localize(str: string, search?: string, replace?: string): string | undefined {
+    return localize(str, search, replace, this.config?.language);
+  }
+
   get entity(): VacuumEntity {
     return this.hass.states[this.config.entity] as VacuumEntity;
   }
@@ -261,8 +265,8 @@ export class VacuumCard extends LitElement {
       options: sources,
       onSelect: this.handleSpeed,
       formatLabel: (value: string) =>
-        localize(`source.${value.toLowerCase()}`) ?? value,
-      ariaLabel: localize('source.fan_speed') || 'Fan speed',
+        this.localize(`source.${value.toLowerCase()}`) ?? value,
+      ariaLabel: this.localize('source.fan_speed') || 'Fan speed',
     });
   }
 
@@ -345,12 +349,35 @@ export class VacuumCard extends LitElement {
     `;
   }
 
+  private getThresholdColor(
+    value: string,
+    thresholds?: { value: number; color: string }[],
+  ): string | undefined {
+    if (!thresholds || thresholds.length === 0) {
+      return undefined;
+    }
+
+    const numValue = parseFloat(value);
+    if (isNaN(numValue)) {
+      return undefined;
+    }
+
+    const sorted = [...thresholds].sort((a, b) => a.value - b.value);
+    for (const threshold of sorted) {
+      if (numValue < threshold.value) {
+        return threshold.color;
+      }
+    }
+
+    return undefined;
+  }
+
   private renderStats(state: VacuumEntityState): Template {
     const statsList =
       this.config.stats[state] || this.config.stats.default || [];
 
     const stats = statsList.map(
-      ({ entity_id, attribute, value_template, unit, subtitle }) => {
+      ({ entity_id, attribute, value_template, unit, subtitle, thresholds }) => {
         if (!entity_id && !attribute) {
           return nothing;
         }
@@ -367,6 +394,8 @@ export class VacuumCard extends LitElement {
           return nothing;
         }
 
+        const color = this.getThresholdColor(state, thresholds);
+
         const value = html`
           <ha-template
             hass=${this.hass}
@@ -378,7 +407,9 @@ export class VacuumCard extends LitElement {
 
         return html`
           <div class="stats-block" @click="${() => this.handleMore(entity_id)}">
-            <span class="stats-value">${value}</span>
+            <span class="stats-value" style=${color ? `color: ${color}` : ''}>
+              ${value}
+            </span>
             ${unit}
             <div class="stats-subtitle">${subtitle}</div>
           </div>
@@ -406,7 +437,7 @@ export class VacuumCard extends LitElement {
   private renderStatus(): Template {
     const { status } = this.getAttributes(this.entity);
     const localizedStatus =
-      localize(`status.${status.toLowerCase()}`) || status;
+      this.localize(`status.${status.toLowerCase()}`) || status;
 
     if (!this.config.show_status) {
       return nothing;
@@ -440,15 +471,15 @@ export class VacuumCard extends LitElement {
           <div class="toolbar">
             <paper-button @click="${this.handleVacuumAction('pause')}">
               <ha-icon icon="hass:pause"></ha-icon>
-              ${localize('common.pause')}
+              ${this.localize('common.pause')}
             </paper-button>
             <paper-button @click="${this.handleVacuumAction('stop')}">
               <ha-icon icon="hass:stop"></ha-icon>
-              ${localize('common.stop')}
+              ${this.localize('common.stop')}
             </paper-button>
             <paper-button @click="${this.handleVacuumAction('return_to_base')}">
               <ha-icon icon="hass:home-map-marker"></ha-icon>
-              ${localize('common.return_to_base')}
+              ${this.localize('common.return_to_base')}
             </paper-button>
           </div>
         `;
@@ -464,11 +495,11 @@ export class VacuumCard extends LitElement {
               })}"
             >
               <ha-icon icon="hass:play"></ha-icon>
-              ${localize('common.continue')}
+              ${this.localize('common.continue')}
             </paper-button>
             <paper-button @click="${this.handleVacuumAction('return_to_base')}">
               <ha-icon icon="hass:home-map-marker"></ha-icon>
-              ${localize('common.return_to_base')}
+              ${this.localize('common.return_to_base')}
             </paper-button>
           </div>
         `;
@@ -484,11 +515,11 @@ export class VacuumCard extends LitElement {
               })}"
             >
               <ha-icon icon="hass:play"></ha-icon>
-              ${localize('common.continue')}
+              ${this.localize('common.continue')}
             </paper-button>
             <paper-button @click="${this.handleVacuumAction('pause')}">
               <ha-icon icon="hass:pause"></ha-icon>
-              ${localize('common.pause')}
+              ${this.localize('common.pause')}
             </paper-button>
           </div>
         `;
@@ -513,7 +544,7 @@ export class VacuumCard extends LitElement {
 
         const dockButton = html`
           <ha-icon-button
-            label="${localize('common.return_to_base')}"
+            label="${this.localize('common.return_to_base')}"
             @click="${this.handleVacuumAction('return_to_base')}"
             ><ha-icon icon="hass:home-map-marker"></ha-icon>
           </ha-icon-button>
@@ -522,13 +553,13 @@ export class VacuumCard extends LitElement {
         return html`
           <div class="toolbar">
             <ha-icon-button
-              label="${localize('common.start')}"
+              label="${this.localize('common.start')}"
               @click="${this.handleVacuumAction('start')}"
               ><ha-icon icon="hass:play"></ha-icon>
             </ha-icon-button>
 
             <ha-icon-button
-              label="${localize('common.locate')}"
+              label="${this.localize('common.locate')}"
               @click="${this.handleVacuumAction('locate', { request: false })}"
               ><ha-icon icon="mdi:map-marker"></ha-icon>
             </ha-icon-button>
@@ -548,7 +579,7 @@ export class VacuumCard extends LitElement {
         <div class="preview not-available">
           <div class="metadata">
             <div class="not-available">
-              ${localize('common.not_available')}
+              ${this.localize('common.not_available')}
             </div>
           <div>
         </div>
@@ -563,7 +594,7 @@ export class VacuumCard extends LitElement {
 
     return html`
       <ha-card>
-        <ha-ripple></ha-ripple>
+        ${this.config.ha_ripple ? html`<ha-ripple></ha-ripple>` : nothing}
         <div class="preview">
           <div class="header">
             <div class="tips">


### PR DESCRIPTION
feat: Add language, stats thresholds, and ha_ripple config options

## Summary

This PR adds three new configuration options:

### 1. `language` — Force UI language
Allows overriding the card's display language regardless of the
browser/HA locale setting.

```yaml
language: tr  # en, de, fr, ru, etc.

Supported languages: ca, cn, cs, da, de, en, es, fi, fr, he, hu,
it, ja, ko, lt, nb, nl, nn, pl, pt, pt-br, ro, ru, sv, tr, tw, uk, vi

2. thresholds — Color-coded stat values

Allows defining color thresholds on stats blocks so values change
color when they drop below a certain level.

stats:
  default:
    - entity_id: sensor.main_brush_time_left
      unit: h
      subtitle: Main Brush
      thresholds:
        - value: 20
          color: "#e53935"   # red  — below 20h
        - value: 50
          color: "#ffb300"   # amber — below 50h

3. ha_ripple — Toggle ripple effect

Enables or disables the <ha-ripple> element on the card.
Defaults to false.
ha_ripple: true   # false by default