### PR TITLE
fix: update stats templates when referenced entities change

### DIFF
--- a/src/vacuum-card.ts
+++ b/src/vacuum-card.ts
@@ -99,7 +99,42 @@ export class VacuumCard extends LitElement {
   }
 
   public shouldUpdate(changedProps: PropertyValues): boolean {
-    return hasConfigOrEntityChanged(this, changedProps, false);
+    if (hasConfigOrEntityChanged(this, changedProps, false)) {
+      return true;
+    }
+
+    const oldHass = changedProps.get('hass') as HomeAssistant | undefined;
+    if (!oldHass || !this.config) {
+      return false;
+    }
+
+    const trackedEntities = new Set<string>();
+
+    if (this.config.entity) {
+      trackedEntities.add(this.config.entity);
+    }
+    if (this.config.map) {
+      trackedEntities.add(this.config.map);
+    }
+    if (this.config.battery_entity) {
+      trackedEntities.add(this.config.battery_entity);
+    }
+
+    Object.values(this.config.stats || {}).forEach((statEntries) => {
+      statEntries.forEach(({ entity_id }) => {
+        if (entity_id) {
+          trackedEntities.add(entity_id);
+        }
+      });
+    });
+
+    for (const entityId of trackedEntities) {
+      if (oldHass.states[entityId] !== this.hass.states[entityId]) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   protected updated(changedProps: PropertyValues) {


### PR DESCRIPTION
Fixes #1057

The card was only rerendering when the main vacuum entity changed. Stats rows that reference separate sensor entities (including value_template output) could become stale until a full frontend reload.

This change extends shouldUpdate to also watch configured stats entities, map entity, and optional battery entity so template-driven stats update in real time.

Greetings, saschabuehrle