### PR TITLE
fix(i18n): show SmartPlan for smart_mode fan speed

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -33,6 +33,7 @@
     "normal": "Normal",
     "max": "Max",
     "max_plus": "Max+",
+    "smart_mode": "SmartPlan",
     "high": "High",
     "strong": "Strong",
     "quiet": "Quiet",

--- a/src/translations/nb.json
+++ b/src/translations/nb.json
@@ -33,6 +33,7 @@
     "normal": "Normal",
     "max": "Maks",
     "max_plus": "Maks+",
+    "smart_mode": "SmartPlan",
     "high": "Høy",
     "strong": "Sterk",
     "quiet": "Stille",


### PR DESCRIPTION
Add SmartPlan labels for smart_mode in English and Norwegian Bokmal so Roborock fan speed names match Home Assistant. Closes #1111.