### PR TITLE
Update French translation

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -39,7 +39,14 @@
     "auto": "Auto",
     "balanced": "Balanced",
     "custom": "Custom",
-    "off": "Off"
+    "off": "Off",
+    "fan_speed": "Mode",
+    "all": "Regular",
+    "short": "Fast mode",
+    "floor": "Floor only",
+    "water": "Water line",
+    "ultra": "Ultra clean",
+    "pickup": "Pickup"
   },
   "common": {
     "name": "Vacuum Card",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -39,7 +39,14 @@
     "auto": "Automatique",
     "balanced": "Équilibré",
     "custom": "Personnalisé",
-    "off": "Arrêt"
+    "off": "Arrêt",
+    "fan_speed": "Vitesse du ventilateur",
+    "all": "Régulier",
+    "short": "Mode rapide",
+    "floor": "Sol uniquement",
+    "water": "Ligne d'eau",
+    "ultra": "Ultra propre",
+    "pickup": "Récupération"
   },
   "common": {
     "name": "Carte aspirateur",


### PR DESCRIPTION
Adds the fan speed values used by Maytronics Dolphin pool cleaners to the
French translation: Regular, Fast mode, Floor only, Water line, Ultra clean,
Pickup. Also adds the missing aria-label for the fan_speed dropdown.

These keys are exposed by the MyDolphin Plus integration and are not shared
with regular vacuum cleaners, so the dropdown was previously falling back to
raw values (all, short, floor, water, ultra, pickup) for French users.