### PR TITLE
Add getEntitySuggestion for vacuum entities

### DIFF
--- a/src/vacuum-card.ts
+++ b/src/vacuum-card.ts
@@ -605,4 +605,16 @@ window.customCards.push({
   type: 'vacuum-card',
   name: localize('common.name'),
   description: localize('common.description'),
+  getEntitySuggestion: (hass: HomeAssistant, entityId: string) => {
+    if (entityId.split('.')[0] !== 'vacuum' || !hass.states[entityId]) {
+      return null;
+    }
+
+    return {
+      config: {
+        type: 'custom:vacuum-card',
+        entity: entityId,
+      },
+    };
+  },
 });


### PR DESCRIPTION
The card now suggests itself in the card picker (Community section) when you
pick a vacuum entity, available in Home Assistant 2026.6.

Docs: https://developers.home-assistant.io/docs/frontend/custom-ui/custom-card#suggesting-your-card-for-an-entity

<img width="1057" height="724" alt="CleanShot 2026-06-03 at 12 24 35" src="https://github.com/user-attachments/assets/4c6ff68b-79fd-4296-8308-f0872ab4d33e" />
