### PR TITLE
feat: add name config field to override displayed vacuum name

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Here is what every option means:
 | ---------------- | :-------: | ------------ | --------------------------------------------------------------------------------------------------------- |
 | `type`           | `string`  | **Required** | `custom:vacuum-card`                                                                                      |
 | `entity`         | `string`  | **Required** | An entity_id within the `vacuum` domain.                                                                  |
+| `name`           | `string`  | Optional     | Custom name to display instead of the entity's friendly name.                                             |
 | `battery_entity` | `string`  | Optional     | An entity_id within the `sensor` domain to display battery state and icon.                                |
 | `map`            | `string`  | Optional     | An entity_id within the `camera` domain, for streaming live vacuum map.                                   |
 | `map_refresh`    | `integer` | `5`          | Update interval for map camera in seconds                                                                 |

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ export default function buildConfig(
 
   return {
     entity: config.entity,
+    name: config.name ?? '',
     battery_entity: config.battery_entity ?? '',
     map: config.map ?? '',
     map_refresh: config.map_refresh ?? 5,

--- a/src/editor.css
+++ b/src/editor.css
@@ -13,7 +13,33 @@
   margin-right: 10px;
 }
 
-.option ha-select,
-.option paper-input {
+.option ha-select {
+  width: 100%;
+}
+
+.option.text-field {
+  align-items: stretch;
+}
+
+.option.text-field label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+}
+
+.text-field-label {
+  color: var(--secondary-text-color);
+  font-size: 12px;
+}
+
+.option.text-field input {
+  background: var(--card-background-color, var(--primary-background-color));
+  border: 1px solid var(--divider-color);
+  border-radius: 4px;
+  box-sizing: border-box;
+  color: var(--primary-text-color);
+  font: inherit;
+  padding: 8px 12px;
   width: 100%;
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -43,7 +43,7 @@ export class VacuumCardEditor extends LitElement implements LovelaceCardEditor {
   }
 
   protected render(): Template {
-    if (!this.hass) {
+    if (!this.hass || !this.config) {
       return nothing;
     }
 
@@ -115,13 +115,28 @@ export class VacuumCardEditor extends LitElement implements LovelaceCardEditor {
           </ha-select>
         </div>
 
-        <div class="option">
-          <paper-input
-            label="${localize('editor.image')}"
-            .value=${this.image}
-            .configValue=${'image'}
-            @value-changed=${this.valueChanged}
-          ></paper-input>
+        <div class="option text-field">
+          <label>
+            <span class="text-field-label">${localize('editor.name')}</span>
+            <input
+              type="text"
+              .value=${this.config.name}
+              .configValue=${'name'}
+              @input=${this.valueChanged}
+            />
+          </label>
+        </div>
+
+        <div class="option text-field">
+          <label>
+            <span class="text-field-label">${localize('editor.image')}</span>
+            <input
+              type="text"
+              .value=${this.image}
+              .configValue=${'image'}
+              @input=${this.valueChanged}
+            />
+          </label>
         </div>
 
         <div class="option">
@@ -207,7 +222,9 @@ export class VacuumCardEditor extends LitElement implements LovelaceCardEditor {
         this.config = {
           ...this.config,
           [target.configValue]:
-            target.checked !== undefined ? target.checked : target.value,
+            target.tagName !== 'INPUT' && target.checked !== undefined
+              ? target.checked
+              : target.value,
         };
       }
     }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -61,6 +61,7 @@
   },
   "editor": {
     "entity": "Entity (Required)",
+    "name": "Name (Optional)",
     "battery_entity": "Battery Entity (Optional)",
     "map": "Map Camera (Optional)",
     "image": "Image (Optional)",

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,7 @@ export interface VacuumCardShortcut {
 
 export interface VacuumCardConfig {
   entity: string;
+  name: string;
   battery_entity: string;
   map: string;
   map_refresh: number;

--- a/src/vacuum-card.ts
+++ b/src/vacuum-card.ts
@@ -400,7 +400,9 @@ export class VacuumCard extends LitElement {
       return nothing;
     }
 
-    return html` <div class="vacuum-name">${friendly_name}</div> `;
+    return html`
+      <div class="vacuum-name">${this.config.name || friendly_name}</div>
+    `;
   }
 
   private renderStatus(): Template {


### PR DESCRIPTION
Adds an optional `name` config field that overrides the card's displayed vacuum name, falling back to the entity's friendly_name when unset (default `''`). Exposed in both YAML config and the visual editor, right after Map Camera and before Image.

Also fixes two pre-existing editor bugs surfaced while building this: render() crashed with "Cannot read properties of undefined (reading 'entity')" when a host set `.hass` before calling `.setConfig()` (Home Assistant's newer Sections dashboard editor does this), and the image field's `paper-input` was invisible on a recent Home Assistant install since HA has dropped that legacy Polymer element from its frontend bundle - and its replacement, ha-textfield, is unavailable to third-party cards under HA's Scoped Custom Element Registry. Both the name and image editor fields now use a plain native <input>, which has no dependency on any custom element registry.